### PR TITLE
Some simple fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,9 +420,7 @@ pub trait Modulator {
     fn elapsed_us(&self) -> u64;
 
     /// Allow donwcasting.
-    fn as_any(&mut self) -> &mut Any where Self: 'static + Sized {
-        self
-    }
+    fn as_any(&mut self) -> &mut Any;
 
     /// Check if the modulator is disabled
     fn enabled(&self) -> bool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 //!
 //! # Modulator
 //!
@@ -80,12 +82,16 @@
 //!
 //! Let `m` be a value of a type that implements the `Modulator` trait, then:
 //!
-//!     let value = m.value();
+//! ```ignore
+//! let value = m.value();
+//! ```
 //!
 //! returns the current value of the modulator. To evolve the modulator by `dt`
 //! microseconds use:
 //!
-//!     m.advance(dt);
+//! ```ignore
+//! m.advance(dt);
+//! ```
 //!
 //! In practice, the latter is rarely done directly, as using an _environment_ (a host
 //! for modulators) such as the included `ModulatorEnv` type, is much more convenient.
@@ -96,11 +102,13 @@
 //! The `ModulatorEnv<T>` type is an _owning host_ for modulators. Generally, you create
 //! one or more environments in your application, such as:
 //!
-//!     // Somewhere in a struct...
-//!     m1: ModulatorEnv<f32>, // hosts modulators that give scalar f32 values
+//! ```ignore
+//! // Somewhere in a struct...
+//! m1: ModulatorEnv<f32>, // hosts modulators that give scalar f32 values
 //!
-//!     // Somewhere in constructor of that struct...
-//!     m1: ModulatorEnv::new(),
+//! // Somewhere in constructor of that struct...
+//! m1: ModulatorEnv::new(),
+//! ```
 //!
 //! The above creates a modulator environment `m1` in a struct, probably a modulation
 //! struct that collects all state/data related to modulation for the app.
@@ -108,8 +116,10 @@
 //! Then, somewhere in the application, the environment must be _ticked_ forward by the
 //! elapsed `dt` microseconds of the current frame, like this:
 //!
-//!     // Here st is the modulation data struct that contains m1, dt is elapsed micros
-//!     st.m1.advance(dt);
+//! ```ignore
+//! // Here st is the modulation data struct that contains m1, dt is elapsed micros
+//! st.m1.advance(dt);
+//! ```
 //!
 //! The environment advances all the enabled modulators it hosts. It is important
 //! to notice two things about `ModulatorEnv`:
@@ -132,13 +142,15 @@
 //! amplitude and frequency values. Since it uses a closure it can actually make
 //! any signal: a waveform, a constant, a random number, etc. For example:
 //!
-//!     // Create a sine wave modulator, initial amplitude of 1 and frequency of 0.5Hz
-//!     let wave = Wave::new(1.0, 0.5).wave(Box::new(|w, t| {
-//!             (t * w.frequency * f32::consts::PI * 2.0).sin() * w.amplitude
-//!         }));
+//! ```ignore
+//! // Create a sine wave modulator, initial amplitude of 1 and frequency of 0.5Hz
+//! let wave = Wave::new(1.0, 0.5).wave(Box::new(|w, t| {
+//!         (t * w.frequency * f32::consts::PI * 2.0).sin() * w.amplitude
+//!     }));
 //!
-//!     // Give the modulator to the environment
-//!     st.m1.take("wave_sin", Box::new(wave));
+//! // Give the modulator to the environment
+//! st.m1.take("wave_sin", Box::new(wave));
+//! ```
 //!
 //! This creates a wave modulator that produces a sine with amplitude 1 and frequency
 //! of 0.5Hz. The closure receives the modulator `w` and elapsed time (t: `f32`) in
@@ -149,15 +161,17 @@
 //!
 //! Another example:
 //!
-//!     // Create a wave modulator, amplitude (2.0) here is used to define walk bounds,
-//!     // while frequency (0.1) is the random range the value moves each time it advances
-//!     let wave = Wave::new(2.0, 0.1).wave(Box::new(|w, _| {
-//!         let n = w.value + thread_rng().gen_range(-w.frequency, w.frequency);
-//!         f32::min(f32::max(n, -w.amplitude), w.amplitude)
-//!     }));
+//! ```ignore
+//! // Create a wave modulator, amplitude (2.0) here is used to define walk bounds,
+//! // while frequency (0.1) is the random range the value moves each time it advances
+//! let wave = Wave::new(2.0, 0.1).wave(Box::new(|w, _| {
+//!     let n = w.value + thread_rng().gen_range(-w.frequency, w.frequency);
+//!     f32::min(f32::max(n, -w.amplitude), w.amplitude)
+//! }));
 //!
-//!     // Now give the modulator to the environment
-//!     st.m1.take("wave_rnd", Box::new(wave));
+//! // Now give the modulator to the environment
+//! st.m1.take("wave_rnd", Box::new(wave));
+//! ```
 //!
 //! This closure offsets the modulator's current value each `advance(dt)` by a random
 //! offset (set by frequency) and caps it between -/+ amplitude. This creates a
@@ -166,8 +180,10 @@
 //! Once the modulators above have been created and given to the host, their value can be
 //! read anytime as follows:
 //!
-//!     let v0 = st.m1.value("wave_sin"); // current value of sine modulator
-//!     let v1 = st.m1.value("wave_rnd"); // current value of random walk modulator
+//! ```ignore
+//! let v0 = st.m1.value("wave_sin"); // current value of sine modulator
+//! let v1 = st.m1.value("wave_rnd"); // current value of random walk modulator
+//! ```
 //!
 //! **Modulator details**
 //! -----
@@ -235,9 +251,11 @@
 //! calculations at destination points, addressed by the symbolic name that was
 //! given to the host when added. For example:
 //!
-//!     // Here we are updating some value by scaling it with a modulator, source
-//!     // is the name of the modulator in environment m1
-//!     self.height = self.base + self.range * st.m1.value(source);
+//! ```ignore
+//! // Here we are updating some value by scaling it with a modulator, source
+//! // is the name of the modulator in environment m1
+//! self.height = self.base + self.range * st.m1.value(source);
+//! ```
 //!
 //! Still, at times you will want to access a modulator out of an environment and
 //! modify something about it, perhaps to modulate one of its settings
@@ -248,20 +266,24 @@
 //! amplitude of our previous `"wave_sin"` modulator by another modulator, in the
 //! same environment, called `"amp_mod"`:
 //!
-//!     let ampmod = st.m1.value("amp_mod"); // amplitude modulation value
-//!     if let Some(sw) = st.m1.get_mut("wave_sin") { // borrow trait object
-//!         if let Some(ss) = sw.as_any().downcast_mut::<Wave>() { // safely cast it
-//!             ss.amplitude = 1.0 + ampmod; // modify its amplitude attribute
-//!         }
+//! ```ignore
+//! let ampmod = st.m1.value("amp_mod"); // amplitude modulation value
+//! if let Some(sw) = st.m1.get_mut("wave_sin") { // borrow trait object
+//!     if let Some(ss) = sw.as_any().downcast_mut::<Wave>() { // safely cast it
+//!         ss.amplitude = 1.0 + ampmod; // modify its amplitude attribute
 //!     }
+//! }
+//! ```
 //!
 //! Here, we read the current value of `"amp_mod"` then we mutably borrow a reference
 //! to the `"wave_sin"` trait object. The `as_any()` method is part of the `Modulator`
-//! trait, so all modulators must implement this conversion, typically just like this:
+//! trait, so all modulators implement this conversion through a default trait method:
 //!
-//!     fn as_any(&mut self) -> &mut Any {
-//!         self
-//!     }
+//! ```ignore
+//! fn as_any(&mut self) -> &mut Any where Self: 'static + Sized {
+//!     self
+//! }
+//! ```
 //!
 //! Once the trait object has been converted into an `Any` we use the `downcast_mut`
 //! method to safely convert it to its original type, which of course must be known.
@@ -284,11 +306,13 @@
 //!
 //! Finally, notice the modulator enabled status methods:
 //!
-//!     /// Check if the modulator is disabled
-//!     fn enabled(&self) -> bool;
+//! ```ignore
+//! /// Check if the modulator is disabled
+//! fn enabled(&self) -> bool;
 //!
-//!     /// Toggle enabling/disabling the modulator
-//!     fn set_enabled(&mut self, enabled: bool);
+//! /// Toggle enabling/disabling the modulator
+//! fn set_enabled(&mut self, enabled: bool);
+//! ```
 //!
 //! Notice that `ModulatorEnv` checks the enabled status of its modulators and will
 //! __not__ advance them if they are disabled. This allows the pausing/unpausing of
@@ -393,7 +417,9 @@ pub trait Modulator<T> {
     fn elapsed_us(&self) -> u64;
 
     /// Allow donwcasting.
-    fn as_any(&mut self) -> &mut Any;
+    fn as_any(&mut self) -> &mut Any where Self: 'static + Sized {
+        self
+    }
 
     /// Check if the modulator is disabled
     fn enabled(&self) -> bool;

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -8,7 +8,6 @@
 extern crate rand;
 
 use sources::rand::prelude::*;
-use std::any::Any;
 use std::f32;
 
 use Modulator;
@@ -19,15 +18,21 @@ use ModulatorEnv;
 /// closure receives self, elapsed time (in seconds) and returns a new value.
 //
 pub struct Wave {
+    /// wave amplitude
     pub amplitude: f32,
+    /// wave frequency
     pub frequency: f32,
 
-    pub wave: Box<Fn(&Wave, f32) -> f32>, // wave closure, receives self and time in s
+    /// wave closure, receives self and time in seconds
+    pub wave: Box<Fn(&Wave, f32) -> f32>,
 
-    pub time: u64,  // accumulated microseconds
-    pub value: f32, // current value
+    /// accumulated microseconds
+    pub time: u64,
+    /// current value
+    pub value: f32,
 
-    pub enabled: bool, // enabling toggle
+    /// enabling toggle
+    pub enabled: bool,
 }
 
 impl Wave {
@@ -73,9 +78,6 @@ impl Modulator<f32> for Wave {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
-        self
-    }
 
     fn enabled(&self) -> bool {
         self.enabled
@@ -100,16 +102,23 @@ impl Modulator<f32> for Wave {
 ///
 
 pub struct ScalarSpring {
-    pub smooth: f32, // spring delay (smoothing), in seconds
-    pub undamp: f32, // artificial undamping (adds overshoot)
+    /// spring delay (smoothing), in seconds
+    pub smooth: f32,
+    /// artificial undamping (adds overshoot)
+    pub undamp: f32,
 
-    pub goal: f32,  // current target for the spring
-    pub value: f32, // current position of the spring (value)
+    /// current target for the spring
+    pub goal: f32,
+    /// current position of the spring (value)
+    pub value: f32,
 
-    pub vel: f32,  // current velocity
-    pub time: u64, // accumulated microseconds
+    /// current velocity
+    pub vel: f32,
+    /// accumulated microseconds
+    pub time: u64,
 
-    pub enabled: bool, // enabling toggle
+    /// enabling toggle
+    pub enabled: bool,
 }
 
 impl ScalarSpring {
@@ -159,9 +168,6 @@ impl Modulator<f32> for ScalarSpring {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
-        self
-    }
 
     fn enabled(&self) -> bool {
         self.enabled
@@ -209,21 +215,31 @@ impl Modulator<f32> for ScalarSpring {
 ///
 
 pub struct ScalarGoalFollower {
-    pub regions: Vec<[f32; 2]>, // set of regions to pick goals from
-    pub random_region: bool,    //  cycle regions randomly instead of sequentially
+    /// set of regions to pick goals from
+    pub regions: Vec<[f32; 2]>,
+    /// cycle regions randomly instead of sequentially
+    pub random_region: bool,
 
-    pub threshold: f32, // threshold to consider a goal reached and move on to next one
-    pub vel_threshold: f32, // as above, but for velocity
+    /// threshold to consider a goal reached and move on to next one
+    pub threshold: f32,
+    /// as above, but for velocity
+    pub vel_threshold: f32,
 
-    pub pause_range: [u64; 2], // range of pause microseconds to pick between goals
+    /// range of pause microseconds to pick between goals
+    pub pause_range: [u64; 2],
 
-    pub follower: Box<dyn Modulator<f32>>, // the modulator that follows the current goal
+    /// the modulator that follows the current goal
+    pub follower: Box<dyn Modulator<f32>>,
 
-    pub current_region: usize, // index of last region used to set the goal
-    pub paused_left: u64,      // when set, number of microseconds until the pause ends
-    pub time: u64,             // accumulated microseconds
+    /// index of last region used to set the goal
+    pub current_region: usize,
+    /// when set, number of microseconds until the pause ends
+    pub paused_left: u64,
+    /// accumulated microseconds
+    pub time: u64,
 
-    pub enabled: bool, // enabling toggle
+    /// enabling toggle
+    pub enabled: bool,
 }
 
 impl ScalarGoalFollower {
@@ -306,9 +322,6 @@ impl Modulator<f32> for ScalarGoalFollower {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
-        self
-    }
 
     fn enabled(&self) -> bool {
         self.enabled
@@ -371,16 +384,23 @@ impl Modulator<f32> for ScalarGoalFollower {
 ///
 
 pub struct Newtonian {
-    pub speed_limit: [f32; 2], // max speed range, selected on new goal
+    /// max speed range, selected on new goal
+    pub speed_limit: [f32; 2],
 
-    pub acceleration: [f32; 2], // range of acceleration values selected on new goal
-    pub deceleration: [f32; 2], // range of deceleration values selected on new goal
+    /// range of acceleration values selected on new goal
+    pub acceleration: [f32; 2],
+    /// range of deceleration values selected on new goal
+    pub deceleration: [f32; 2],
 
-    pub goal: f32,  // current goal
-    pub value: f32, // current position of the particle (value)
+    /// current goal
+    pub goal: f32,
+    /// current position of the particle (value)
+    pub value: f32,
 
-    pub time: u64,     // accumulated microseconds since the most recent goal was set
-    pub enabled: bool, // enabling toggle
+    /// accumulated microseconds since the most recent goal was set
+    pub time: u64,
+    /// enabling toggle
+    pub enabled: bool,
 
     s: f32,      // speed selected for the current goal
     a: f32,      // accel selected towards the goal
@@ -525,9 +545,6 @@ impl Modulator<f32> for Newtonian {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
-        self
-    }
 
     fn enabled(&self) -> bool {
         self.enabled
@@ -581,27 +598,40 @@ impl Modulator<f32> for Newtonian {
 ///
 
 pub struct ShiftRegister {
-    pub buckets: Vec<f32>, // current array of values
-    pub ages: Vec<u32>,    // symmetrical array of value ages (number of periods since updating)
+    /// current array of values
+    pub buckets: Vec<f32>,
+    /// symmetrical array of value ages (number of periods since updating)
+    pub ages: Vec<u32>,
 
-    pub value_range: [f32; 2], // range of values selected when picking a bucket value [..)
-    pub odds: f32, // odds of changing a bucket's value as it is left, 0..1 (0 = never, 1 = always)
-    pub age_range: [u32; 2], // min/max range over which the odds increase to 100%
+    /// range of values selected when picking a bucket value [..)
+    pub value_range: [f32; 2],
+    /// odds of changing a bucket's value as it is left, 0..1 (0 = never, 1 = always)
+    pub odds: f32,
+    /// min/max range over which the odds increase to 100%
+    pub age_range: [u32; 2],
 
-    pub period: f32,                 // duration of a register loop, in seconds
-    pub interp: ShiftRegisterInterp, // interpolation type
+    /// duration of a register loop, in seconds
+    pub period: f32,
+    /// interpolation type
+    pub interp: ShiftRegisterInterp,
 
-    pub time: u64,  // accumulated microseconds, local time within the register loop
-    pub value: f32, // current value
+    /// accumulated microseconds, local time within the register loop
+    pub time: u64,
+    /// current value
+    pub value: f32,
 
-    pub enabled: bool, // enabling toggle
+    /// enabling toggle
+    pub enabled: bool,
 }
 
 /// Available choices of interpolation for shift registers
 pub enum ShiftRegisterInterp {
-    Linear,    // linearly interpolate between samples
-    Quadratic, // quadratic interpolation between the samples
-    None,      // no interpolation, buckets are read directly
+    /// linearly interpolate between samples
+    Linear,
+    /// quadratic interpolation between the samples
+    Quadratic,
+    /// no interpolation, buckets are read directly
+    None,
 }
 
 impl ShiftRegister {
@@ -697,9 +727,6 @@ impl Modulator<f32> for ShiftRegister {
 
     fn elapsed_us(&self) -> u64 {
         self.time
-    }
-    fn as_any(&mut self) -> &mut Any {
-        self
     }
 
     fn enabled(&self) -> bool {

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -9,6 +9,7 @@ extern crate rand;
 
 use sources::rand::prelude::*;
 use std::f32;
+use std::any::Any;
 
 use Modulator;
 use ModulatorEnv;
@@ -79,6 +80,10 @@ impl Modulator for Wave {
 
     fn elapsed_us(&self) -> u64 {
         self.time
+    }
+
+    fn as_any(&mut self) -> &mut Any {
+        self
     }
 
     fn enabled(&self) -> bool {
@@ -171,6 +176,10 @@ impl Modulator for ScalarSpring {
 
     fn elapsed_us(&self) -> u64 {
         self.time
+    }
+
+    fn as_any(&mut self) -> &mut Any {
+        self
     }
 
     fn enabled(&self) -> bool {
@@ -327,6 +336,10 @@ impl Modulator for ScalarGoalFollower {
 
     fn elapsed_us(&self) -> u64 {
         self.time
+    }
+
+    fn as_any(&mut self) -> &mut Any {
+        self
     }
 
     fn enabled(&self) -> bool {
@@ -554,6 +567,10 @@ impl Modulator for Newtonian {
         self.time
     }
 
+    fn as_any(&mut self) -> &mut Any {
+        self
+    }
+
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -737,6 +754,10 @@ impl Modulator for ShiftRegister {
 
     fn elapsed_us(&self) -> u64 {
         self.time
+    }
+
+    fn as_any(&mut self) -> &mut Any {
+        self
     }
 
     fn enabled(&self) -> bool {

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -63,7 +63,9 @@ impl Wave {
     }
 }
 
-impl Modulator<f32> for Wave {
+impl Modulator for Wave {
+    type Value = f32;
+
     fn value(&self) -> f32 {
         self.value
     }
@@ -151,7 +153,9 @@ impl ScalarSpring {
     }
 }
 
-impl Modulator<f32> for ScalarSpring {
+impl Modulator for ScalarSpring {
+    type Value = f32;
+
     fn value(&self) -> f32 {
         self.value
     }
@@ -229,7 +233,7 @@ pub struct ScalarGoalFollower {
     pub pause_range: [u64; 2],
 
     /// the modulator that follows the current goal
-    pub follower: Box<dyn Modulator<f32>>,
+    pub follower: Box<dyn Modulator<Value=f32>>,
 
     /// index of last region used to set the goal
     pub current_region: usize,
@@ -244,7 +248,7 @@ pub struct ScalarGoalFollower {
 
 impl ScalarGoalFollower {
     /// Make a scalar goal follower
-    pub fn new(follower: Box<dyn Modulator<f32>>) -> Self {
+    pub fn new(follower: Box<dyn Modulator<Value=f32>>) -> Self {
         ScalarGoalFollower {
             regions: vec![],
             random_region: false,
@@ -288,7 +292,9 @@ impl ScalarGoalFollower {
     }
 }
 
-impl Modulator<f32> for ScalarGoalFollower {
+impl Modulator for ScalarGoalFollower {
+    type Value = f32;
+
     fn value(&self) -> f32 {
         self.follower.value()
     }
@@ -528,7 +534,9 @@ impl Newtonian {
     }
 }
 
-impl Modulator<f32> for Newtonian {
+impl Modulator for Newtonian {
+    type Value = f32;
+
     fn value(&self) -> f32 {
         self.value
     }
@@ -711,7 +719,9 @@ impl ShiftRegister {
     }
 }
 
-impl Modulator<f32> for ShiftRegister {
+impl Modulator for ShiftRegister {
+    type Value = f32;
+
     fn value(&self) -> f32 {
         self.value
     }


### PR DESCRIPTION
- Added `#![deny(missing_docs)]` crate attribute
- Fixed `cargo test` (doc tests)
- Use "```ignore" in docs when not type checked
- Make `as_any` default trait method
- Make `T` associated type on `Modulator` trait, since it mutates internal state