### PR TITLE
Use `generational_arena`, add some default implementations for methods on `Modulator`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modulator"
-version = "0.1.0"
+version = "0.2.0"
 
 description = "A trait for abstracted, decoupled modulation sources"
 authors = ["Andrea Pessino <andrea@readyatdawn.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,8 @@ license  = "MIT"
 repository = "https://github.com/apessino/modulator"
 readme = "readme.md"
 
+edition = "2018"
+
 [dependencies]
-rand = "0.5.5"
+rand = "0.7.2"
+generational-arena = "0.2.3"


### PR DESCRIPTION
This PR uses `generational_arena` instead of a `HashMap` to store `Modulator`s inside of a `ModulatorEnv`. This has a couple tradeoffs:

Pros
+ Constant time lookup and linear iteration, also very cache-friendly on iteration
+ Don't need to create and use unique strings when adding Modulators, which makes for easier use of more advanced patterns like adding Modulators within a loop

Cons
- Need to store the handles to inserted modulators instead of just using a string, which could make very simple cases slightly less ergonomic

I've also
* Updated to Rust 2018
* Updated `rand` to the latest version
* Slightly modified the `Modulator` interface to allow having some default implementations of the methods which are only used by some Modulator types--thus, `Modulator`s which do not use these do not need to implement them.