### PR TITLE
Update to Rust 2018, small improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,7 @@ license  = "MIT"
 repository = "https://github.com/apessino/modulator"
 readme = "readme.md"
 
+edition = "2018"
+
 [dependencies]
-rand = "0.5.5"
+rand = "0.7.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,7 +393,7 @@ pub trait Modulator<T> {
     fn elapsed_us(&self) -> u64;
 
     /// Allow donwcasting.
-    fn as_any(&mut self) -> &mut Any;
+    fn as_any(&mut self) -> &mut dyn Any;
 
     /// Check if the modulator is disabled
     fn enabled(&self) -> bool;

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -5,14 +5,13 @@
 //!
 //! Copyright© 2018 Ready At Dawn Studios
 
-extern crate rand;
+use rand::prelude::*;
 
-use sources::rand::prelude::*;
 use std::any::Any;
 use std::f32;
 
-use Modulator;
-use ModulatorEnv;
+use crate::Modulator;
+use crate::ModulatorEnv;
 
 ///
 /// Simple modulator using a value closure/`Fn`, with frequency and amplitude. The
@@ -22,7 +21,7 @@ pub struct Wave {
     pub amplitude: f32,
     pub frequency: f32,
 
-    pub wave: Box<Fn(&Wave, f32) -> f32>, // wave closure, receives self and time in s
+    pub wave: Box<dyn Fn(&Wave, f32) -> f32>, // wave closure, receives self and time in s
 
     pub time: u64,  // accumulated microseconds
     pub value: f32, // current value
@@ -47,13 +46,13 @@ impl Wave {
     }
 
     /// Builder: set the wave calculation closure
-    pub fn wave(mut self, wave: Box<Fn(&Wave, f32) -> f32>) -> Self {
+    pub fn wave(mut self, wave: Box<dyn Fn(&Wave, f32) -> f32>) -> Self {
         self.wave = wave;
         self
     }
 
     /// Builder: set the wave calculation closure
-    pub fn set_wave(&mut self, wave: Box<Fn(&Wave, f32) -> f32>) {
+    pub fn set_wave(&mut self, wave: Box<dyn Fn(&Wave, f32) -> f32>) {
         self.wave = wave;
     }
 }
@@ -73,7 +72,7 @@ impl Modulator<f32> for Wave {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 
@@ -159,7 +158,7 @@ impl Modulator<f32> for ScalarSpring {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 
@@ -306,7 +305,7 @@ impl Modulator<f32> for ScalarGoalFollower {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 
@@ -525,7 +524,7 @@ impl Modulator<f32> for Newtonian {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 
@@ -698,7 +697,7 @@ impl Modulator<f32> for ShiftRegister {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -7,7 +7,6 @@
 
 use rand::prelude::*;
 
-use std::any::Any;
 use std::f32;
 
 use crate::Modulator;
@@ -61,21 +60,16 @@ impl Modulator<f32> for Wave {
     fn value(&self) -> f32 {
         self.value
     }
-    fn range(&self) -> [f32; 2] {
-        [-self.amplitude, self.amplitude]
+    fn range(&self) -> Option<[f32; 2]> {
+        Some([-self.amplitude, self.amplitude])
     }
-    fn goal(&self) -> f32 {
-        self.value
+    fn goal(&self) -> Option<f32> {
+        Some(self.value)
     }
-    fn set_goal(&mut self, _: f32) {}
 
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -145,11 +139,8 @@ impl Modulator<f32> for ScalarSpring {
     fn value(&self) -> f32 {
         self.value
     }
-    fn range(&self) -> [f32; 2] {
-        [0.0, 0.0] // not meaningful for springs
-    }
-    fn goal(&self) -> f32 {
-        self.goal
+    fn goal(&self) -> Option<f32> {
+        Some(self.goal)
     }
     fn set_goal(&mut self, goal: f32) {
         self.spring_to(goal);
@@ -158,10 +149,6 @@ impl Modulator<f32> for ScalarSpring {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -275,7 +262,7 @@ impl Modulator<f32> for ScalarGoalFollower {
     fn value(&self) -> f32 {
         self.follower.value()
     }
-    fn range(&self) -> [f32; 2] {
+    fn range(&self) -> Option<[f32; 2]> {
         let mut r = if !self.regions.is_empty() {
             self.regions[0]
         } else {
@@ -291,10 +278,10 @@ impl Modulator<f32> for ScalarGoalFollower {
                 r[1] = j[1];
             }
         }
-        r
+        Some(r)
     }
 
-    fn goal(&self) -> f32 {
+    fn goal(&self) -> Option<f32> {
         // these just forward to the follower
         self.follower.goal()
     }
@@ -304,9 +291,6 @@ impl Modulator<f32> for ScalarGoalFollower {
 
     fn elapsed_us(&self) -> u64 {
         self.time
-    }
-    fn as_any(&mut self) -> &mut dyn Any {
-        self
     }
 
     fn enabled(&self) -> bool {
@@ -333,7 +317,8 @@ impl Modulator<f32> for ScalarGoalFollower {
                 0.0
             };
 
-            if (p1 - self.follower.goal()).abs() > self.threshold || vel.abs() > self.vel_threshold
+            if (p1 - self.follower.goal().unwrap()).abs() > self.threshold
+                || vel.abs() > self.vel_threshold
             {
                 return; // still moving towards the goal
             }
@@ -511,23 +496,10 @@ impl Modulator<f32> for Newtonian {
     fn value(&self) -> f32 {
         self.value
     }
-    fn range(&self) -> [f32; 2] {
-        [0.0, 0.0] // not meaningful for these
-    }
-    fn goal(&self) -> f32 {
-        self.goal
-    }
-    fn set_goal(&mut self, goal: f32) {
-        self.move_to(goal);
-    }
 
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -684,21 +656,12 @@ impl Modulator<f32> for ShiftRegister {
     fn value(&self) -> f32 {
         self.value
     }
-    fn range(&self) -> [f32; 2] {
-        self.value_range
-    }
-    fn goal(&self) -> f32 {
-        self.value // not meaningful for these
-    }
-    fn set_goal(&mut self, _: f32) {
-        // ignored
+    fn range(&self) -> Option<[f32; 2]> {
+        Some(self.value_range)
     }
 
     fn elapsed_us(&self) -> u64 {
         self.time
-    }
-    fn as_any(&mut self) -> &mut dyn Any {
-        self
     }
 
     fn enabled(&self) -> bool {


### PR DESCRIPTION
* Updated to Rust 2018
* Updated `rand` to the latest version
* Slightly modified the `Modulator` interface to allow having some default implementations of the methods which are only used by some Modulator types--thus, `Modulator`s which do not use these do not need to implement them.