### PR TITLE
Add new `ModulatorArenaEnv<T>` environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modulator"
-version = "0.1.0"
+version = "0.2.0"
 
 description = "A trait for abstracted, decoupled modulation sources"
 authors = ["Andrea Pessino <andrea@readyatdawn.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ readme = "readme.md"
 edition = "2018"
 
 [dependencies]
+generational-arena = "0.2.3"
 rand = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,7 @@ license  = "MIT"
 repository = "https://github.com/apessino/modulator"
 readme = "readme.md"
 
+edition = "2018"
+
 [dependencies]
-rand = "0.5.5"
+rand = "0.7.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! A trait for abstracted, decoupled modulation sources. This crate includes:
 //!
 //!   1. The `Modulator<T>` trait definition
-//!   2. An environment (host) type for modulators `ModulatorEnv<T>`
+//!   2. Two environment (host) types for modulators, `ModulatorEnv<T>` and `ModulatorArenaEnv<T>`
 //!   3. A number of ready to use types that implement the modulator trait
 //!
 //! **Introduction**
@@ -93,8 +93,8 @@
 //! **Modulator environments**
 //! -----
 //!
-//! The `ModulatorEnv<T>` type is an _owning host_ for modulators. Generally, you create
-//! one or more environments in your application, such as:
+//! The `ModulatorEnv<T>` (and `ModulatorArenaEnv<T>`) type is an _owning host_ for modulators.
+//! Generally, you create one or more environments in your application, such as:
 //!
 //!     // Somewhere in a struct...
 //!     m1: ModulatorEnv<f32>, // hosts modulators that give scalar f32 values
@@ -376,6 +376,9 @@
 //!
 //! Copyright© 2018 Ready At Dawn Studios
 
+use generational_arena::Arena;
+use generational_arena::Index;
+
 use std::any::Any;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -419,7 +422,8 @@ pub trait Modulator<T> {
     fn set_goal(&mut self, _goal: T) {}
 }
 
-/// A host for modulators, homogeneous in type T for the value of its modulators
+/// A host for modulators, homogeneous in type T for the value of its modulators,
+/// stored in a HashMap for convenience and rapid prototyping.
 #[derive(Default)]
 pub struct ModulatorEnv<T> {
     mods: HashMap<String, Box<dyn Modulator<T>>>, // live modulators
@@ -493,6 +497,111 @@ impl<T: Default> ModulatorEnv<T> {
         for v in self.mods.values_mut() {
             if v.enabled() {
                 v.advance(dt);
+            }
+        }
+    }
+
+    /// Convert a duration (secs+nanosecs) into total microseconds
+    pub fn duration_to_micros(time: Duration) -> u64 {
+        time.as_secs() * 1_000_000_u64 + u64::from(time.subsec_nanos()) / 1000_u64
+    }
+    /// Convert microseconds into floating point seconds
+    pub fn micros_to_secs(us: u64) -> f32 {
+        us as f32 / 1.0e6_f32
+    }
+    /// Convert a duration (secs+nanosecs) into floating point seconds
+    pub fn duration_to_secs(time: Duration) -> f32 {
+        Self::micros_to_secs(Self::duration_to_micros(time))
+    }
+}
+
+/// A handle to a specific Modulator within a ModulatorArenaEnv.
+#[derive(Copy, Clone)]
+pub struct ModulatorHandle(Index);
+
+/// A host for modulators, homogeneous in type T for the value of its modulator,
+/// stored in a Vec-like Arena data structure for faster lookup and iteration.
+pub struct ModulatorArenaEnv<T> {
+    mods: Arena<Box<dyn Modulator<T>>>, // live modulators
+}
+
+impl<T> Default for ModulatorArenaEnv<T> {
+    fn default() -> Self {
+        ModulatorArenaEnv { mods: Arena::new() }
+    }
+}
+
+impl<T: Default> ModulatorArenaEnv<T> {
+    /// Create an empty ModulatorEnv
+    pub fn new() -> Self {
+        ModulatorArenaEnv { mods: Arena::new() }
+    }
+
+    /// Take ownership of a Modulator and store it within this environment, returning
+    /// a unique handle to it.
+    pub fn take(&mut self, modulator: Box<dyn Modulator<T>>) -> ModulatorHandle {
+        let index = self.mods.insert(modulator);
+        ModulatorHandle(index)
+    }
+
+    /// Remove the modulator with given key, let it die
+    pub fn kill(&mut self, handle: ModulatorHandle) {
+        self.mods.remove(handle.0); // ignore the return, let the value die
+    }
+
+    /// Take a shared reference to the inner generational_arena which stores the modulators.
+    pub fn get_mods(&self) -> &Arena<Box<dyn Modulator<T>>> {
+        &self.mods
+    }
+
+    /// Try to fetch an immutable reference to the modulator with the given handle
+    pub fn get(&self, handle: ModulatorHandle) -> Option<&Box<dyn Modulator<T>>> {
+        self.mods.get(handle.0)
+    }
+
+    /// Try to fetch an mutable reference to the modulator with the given handle
+    pub fn get_mut(&mut self, handle: ModulatorHandle) -> Option<&mut Box<dyn Modulator<T>>> {
+        self.mods.get_mut(handle.0)
+    }
+
+    /// Return the current value of the given modulator
+    pub fn value(&self, handle: ModulatorHandle) -> T {
+        match self.get(handle) {
+            Some(modulator) if modulator.enabled() => modulator.value(),
+            Some(_) => T::default(),
+            None => T::default(),
+        }
+    }
+
+    /// Return the range of the given modulator
+    pub fn range(&self, handle: ModulatorHandle) -> Option<[T; 2]> {
+        match self.get(handle) {
+            Some(modulator) if modulator.enabled() => modulator.range(),
+            _ => None,
+        }
+    }
+
+    /// Return the current goal of the given modulator
+    pub fn goal(&self, handle: ModulatorHandle) -> Option<T> {
+        match self.get(handle) {
+            Some(modulator) if modulator.enabled() => modulator.goal(),
+            _ => None,
+        }
+    }
+
+    /// Return the current value of the given modulator
+    pub fn elapsed_us(&self, handle: ModulatorHandle) -> u64 {
+        match self.get(handle) {
+            Some(modulator) => modulator.elapsed_us(),
+            None => 0,
+        }
+    }
+
+    /// Advance all owned modulators by dt microseconds
+    pub fn advance(&mut self, dt: u64) {
+        for (_, m) in self.mods.iter_mut() {
+            if m.enabled() {
+                m.advance(dt);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,7 +393,7 @@ pub trait Modulator<T> {
     fn elapsed_us(&self) -> u64;
 
     /// Allow donwcasting.
-    fn as_any(&mut self) -> &mut Any;
+    fn as_any(&mut self) -> &mut dyn Any;
 
     /// Check if the modulator is disabled
     fn enabled(&self) -> bool;

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -5,14 +5,13 @@
 //!
 //! Copyright© 2018 Ready At Dawn Studios
 
-extern crate rand;
+use rand::prelude::*;
 
-use sources::rand::prelude::*;
 use std::any::Any;
 use std::f32;
 
-use Modulator;
-use ModulatorEnv;
+use crate::Modulator;
+use crate::ModulatorEnv;
 
 ///
 /// Simple modulator using a value closure/`Fn`, with frequency and amplitude. The
@@ -22,7 +21,7 @@ pub struct Wave {
     pub amplitude: f32,
     pub frequency: f32,
 
-    pub wave: Box<Fn(&Wave, f32) -> f32>, // wave closure, receives self and time in s
+    pub wave: Box<dyn Fn(&Wave, f32) -> f32>, // wave closure, receives self and time in s
 
     pub time: u64,  // accumulated microseconds
     pub value: f32, // current value
@@ -47,13 +46,13 @@ impl Wave {
     }
 
     /// Builder: set the wave calculation closure
-    pub fn wave(mut self, wave: Box<Fn(&Wave, f32) -> f32>) -> Self {
+    pub fn wave(mut self, wave: Box<dyn Fn(&Wave, f32) -> f32>) -> Self {
         self.wave = wave;
         self
     }
 
     /// Builder: set the wave calculation closure
-    pub fn set_wave(&mut self, wave: Box<Fn(&Wave, f32) -> f32>) {
+    pub fn set_wave(&mut self, wave: Box<dyn Fn(&Wave, f32) -> f32>) {
         self.wave = wave;
     }
 }
@@ -73,7 +72,7 @@ impl Modulator<f32> for Wave {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 
@@ -159,7 +158,7 @@ impl Modulator<f32> for ScalarSpring {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 
@@ -306,7 +305,7 @@ impl Modulator<f32> for ScalarGoalFollower {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 
@@ -525,7 +524,7 @@ impl Modulator<f32> for Newtonian {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 
@@ -698,7 +697,7 @@ impl Modulator<f32> for ShiftRegister {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut Any {
+    fn as_any(&mut self) -> &mut dyn Any {
         self
     }
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -7,7 +7,6 @@
 
 use rand::prelude::*;
 
-use std::any::Any;
 use std::f32;
 
 use crate::Modulator;
@@ -61,21 +60,16 @@ impl Modulator<f32> for Wave {
     fn value(&self) -> f32 {
         self.value
     }
-    fn range(&self) -> [f32; 2] {
-        [-self.amplitude, self.amplitude]
+    fn range(&self) -> Option<[f32; 2]> {
+        Some([-self.amplitude, self.amplitude])
     }
-    fn goal(&self) -> f32 {
-        self.value
+    fn goal(&self) -> Option<f32> {
+        Some(self.value)
     }
-    fn set_goal(&mut self, _: f32) {}
 
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -145,11 +139,8 @@ impl Modulator<f32> for ScalarSpring {
     fn value(&self) -> f32 {
         self.value
     }
-    fn range(&self) -> [f32; 2] {
-        [0.0, 0.0] // not meaningful for springs
-    }
-    fn goal(&self) -> f32 {
-        self.goal
+    fn goal(&self) -> Option<f32> {
+        Some(self.goal)
     }
     fn set_goal(&mut self, goal: f32) {
         self.spring_to(goal);
@@ -158,10 +149,6 @@ impl Modulator<f32> for ScalarSpring {
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -275,7 +262,7 @@ impl Modulator<f32> for ScalarGoalFollower {
     fn value(&self) -> f32 {
         self.follower.value()
     }
-    fn range(&self) -> [f32; 2] {
+    fn range(&self) -> Option<[f32; 2]> {
         let mut r = if !self.regions.is_empty() {
             self.regions[0]
         } else {
@@ -291,10 +278,10 @@ impl Modulator<f32> for ScalarGoalFollower {
                 r[1] = j[1];
             }
         }
-        r
+        Some(r)
     }
 
-    fn goal(&self) -> f32 {
+    fn goal(&self) -> Option<f32> {
         // these just forward to the follower
         self.follower.goal()
     }
@@ -304,9 +291,6 @@ impl Modulator<f32> for ScalarGoalFollower {
 
     fn elapsed_us(&self) -> u64 {
         self.time
-    }
-    fn as_any(&mut self) -> &mut dyn Any {
-        self
     }
 
     fn enabled(&self) -> bool {
@@ -333,7 +317,8 @@ impl Modulator<f32> for ScalarGoalFollower {
                 0.0
             };
 
-            if (p1 - self.follower.goal()).abs() > self.threshold || vel.abs() > self.vel_threshold
+            if (p1 - self.follower.goal().unwrap()).abs() > self.threshold
+                || vel.abs() > self.vel_threshold
             {
                 return; // still moving towards the goal
             }
@@ -511,23 +496,10 @@ impl Modulator<f32> for Newtonian {
     fn value(&self) -> f32 {
         self.value
     }
-    fn range(&self) -> [f32; 2] {
-        [0.0, 0.0] // not meaningful for these
-    }
-    fn goal(&self) -> f32 {
-        self.goal
-    }
-    fn set_goal(&mut self, goal: f32) {
-        self.move_to(goal);
-    }
 
     fn elapsed_us(&self) -> u64 {
         self.time
     }
-    fn as_any(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn enabled(&self) -> bool {
         self.enabled
     }
@@ -684,21 +656,12 @@ impl Modulator<f32> for ShiftRegister {
     fn value(&self) -> f32 {
         self.value
     }
-    fn range(&self) -> [f32; 2] {
-        self.value_range
-    }
-    fn goal(&self) -> f32 {
-        self.value // not meaningful for these
-    }
-    fn set_goal(&mut self, _: f32) {
-        // ignored
+    fn range(&self) -> Option<[f32; 2]> {
+        Some(self.value_range)
     }
 
     fn elapsed_us(&self) -> u64 {
         self.time
-    }
-    fn as_any(&mut self) -> &mut dyn Any {
-        self
     }
 
     fn enabled(&self) -> bool {


### PR DESCRIPTION
This PR adds a new env type which uses a `generational_arena` instead of a `HashMap` to store `Modulator`s. This has a couple tradeoffs:

Pros
+ Constant time lookup and linear iteration, also very cache-friendly on iteration
+ Don't need to create and use unique strings when adding Modulators, which makes for easier use of more advanced patterns like adding Modulators within a loop

Cons
- Need to store the handles to inserted modulators instead of just using a string, which could make very simple cases slightly less ergonomic